### PR TITLE
Support for @UseAsyncMethod

### DIFF
--- a/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/ws/WsdlFirstServiceImpl.java
+++ b/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/ws/WsdlFirstServiceImpl.java
@@ -1,12 +1,17 @@
 package com.roskart.dropwizard.jaxws.example.ws;
 
 import com.codahale.metrics.annotation.Metered;
+import org.apache.cxf.annotations.UseAsyncMethod;
+import org.apache.cxf.jaxws.ServerAsyncResponse;
 import ws.example.jaxws.dropwizard.roskart.com.wsdlfirstservice.Echo;
 import ws.example.jaxws.dropwizard.roskart.com.wsdlfirstservice.EchoResponse;
+import ws.example.jaxws.dropwizard.roskart.com.wsdlfirstservice.NonBlockingEcho;
 import ws.example.jaxws.dropwizard.roskart.com.wsdlfirstservice.WsdlFirstService;
 
 import javax.jws.HandlerChain;
 import javax.jws.WebService;
+import javax.xml.ws.AsyncHandler;
+import java.util.concurrent.Future;
 
 @WebService(endpointInterface = "ws.example.jaxws.dropwizard.roskart.com.wsdlfirstservice.WsdlFirstService",
         targetNamespace = "http://com.roskart.dropwizard.jaxws.example.ws/WsdlFirstService",
@@ -20,6 +25,40 @@ public class WsdlFirstServiceImpl implements WsdlFirstService {
         EchoResponse response = new EchoResponse();
         response.setValue(parameters.getValue());
         return response;
+    }
+
+    @Override
+    @UseAsyncMethod
+    @Metered
+    public EchoResponse nonBlockingEcho(NonBlockingEcho parameters) {
+        EchoResponse response = new EchoResponse();
+        response.setValue("Blocking: " + parameters.getValue());
+        return response;
+    }
+
+    @Metered
+    public Future<EchoResponse> nonBlockingEchoAsync(
+        final NonBlockingEcho parameters,
+        final AsyncHandler<EchoResponse> asyncHandler
+    ) {
+        final ServerAsyncResponse<EchoResponse> sar = new ServerAsyncResponse<>();
+
+        new Thread() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(1000);
+                    EchoResponse response = new EchoResponse();
+                    response.setValue("Non-blocking: " + parameters.getValue());
+                    sar.set(response);
+                } catch (InterruptedException e) {
+                    sar.exception(e);
+                }
+                asyncHandler.handleResponse(sar);
+            }
+        }.start();
+
+        return sar;
     }
 
 }

--- a/dropwizard-jaxws-example/src/main/resources/META-INF/WsdlFirstService.wsdl
+++ b/dropwizard-jaxws-example/src/main/resources/META-INF/WsdlFirstService.wsdl
@@ -14,6 +14,8 @@
       </xsd:element>
       <xsd:element name="EchoResponse" type="tns:EchoResponse">
       </xsd:element>
+      <xsd:element name="NonBlockingEcho" type="tns:NonBlockingEcho">
+      </xsd:element>
 
       <xsd:complexType name="Echo">
       	<xsd:sequence>
@@ -27,6 +29,12 @@
       	</xsd:sequence>
       </xsd:complexType>
 
+      <xsd:complexType name="NonBlockingEcho">
+        <xsd:sequence>
+            <xsd:element name="value" type="xsd:string"></xsd:element>
+        </xsd:sequence>
+      </xsd:complexType>
+
     </xsd:schema>
   </wsdl:types>
   
@@ -36,10 +44,17 @@
   <wsdl:message name="EchoResponse">
   	<wsdl:part name="parameters" element="tns:EchoResponse"></wsdl:part>
   </wsdl:message>
+  <wsdl:message name="NonBlockingEchoRequest">
+    <wsdl:part name="parameters" element="tns:NonBlockingEcho"></wsdl:part>
+  </wsdl:message>
 
   <wsdl:portType name="WsdlFirstService">
     <wsdl:operation name="echo">
     	<wsdl:input message="tns:EchoRequest"></wsdl:input>
+    	<wsdl:output message="tns:EchoResponse"></wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="nonBlockingEcho">
+    	<wsdl:input message="tns:NonBlockingEchoRequest"></wsdl:input>
     	<wsdl:output message="tns:EchoResponse"></wsdl:output>
     </wsdl:operation>
   </wsdl:portType>
@@ -47,6 +62,15 @@
   <wsdl:binding name="WsdlFirstServiceSOAP" type="tns:WsdlFirstService">
     <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
     <wsdl:operation name="echo">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="nonBlockingEcho">
       <soap:operation soapAction="" style="document"/>
       <wsdl:input>
         <soap:body use="literal"/>

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/ValidatingInvoker.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/ValidatingInvoker.java
@@ -13,6 +13,7 @@ import javax.validation.Validator;
 import javax.validation.Valid;
 import javax.validation.ValidationException;
 import javax.validation.groups.Default;
+import javax.xml.ws.AsyncHandler;
 import java.lang.annotation.Annotation;
 import java.util.List;
 
@@ -51,7 +52,9 @@ public class ValidatingInvoker extends AbstractInvoker {
             int i = 0;
             try {
                 for (Object parameter : params) {
-                    validate(parameterAnnotations[i++], parameter);
+                    if(parameter == null || !AsyncHandler.class.isAssignableFrom(parameter.getClass())) {
+                        validate(parameterAnnotations[i++], parameter);
+                    }
                 }
             }
             catch (ValidationException ve) {

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/ValidatingInvokerTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/ValidatingInvokerTest.java
@@ -2,6 +2,7 @@ package com.roskart.dropwizard.jaxws;
 
 import io.dropwizard.validation.Validated;
 import io.dropwizard.validation.ValidationMethod;
+import org.apache.cxf.annotations.UseAsyncMethod;
 import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.service.invoker.Invoker;
@@ -14,9 +15,12 @@ import org.junit.Test;
 import javax.validation.Validation;
 import javax.validation.Valid;
 import javax.validation.ValidationException;
+import javax.xml.ws.AsyncHandler;
+import javax.xml.ws.Response;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -67,6 +71,11 @@ public class ValidatingInvokerTest {
         }
         public void withDropwizardValidation(@Validated() String foo) {
         }
+        @UseAsyncMethod
+        public void asyncMethod(String foo) {
+        }
+        public void asyncMethodAsync(String foo, AsyncHandler asyncHandler) {
+        }
     }
 
     @Before
@@ -112,6 +121,29 @@ public class ValidatingInvokerTest {
         verify(underlying).invoke(exchange, params);
 
         params = Arrays.asList(new RootParam1(null), new RootParam2(null));
+        invoker.invoke(exchange, params);
+        verify(underlying).invoke(exchange, params);
+    }
+
+    @Test
+    public void invokeWithAsycHandler() {
+        setTargetMethod(exchange, "asyncMethod", String.class);
+
+        List<Object> params = Arrays.<Object>asList(null, new AsyncHandler(){
+            @Override
+            public void handleResponse(Response res) {
+
+            }
+        });
+        invoker.invoke(exchange, params);
+        verify(underlying).invoke(exchange, params);
+
+        params = Arrays.asList("foo", new AsyncHandler(){
+            @Override
+            public void handleResponse(Response res) {
+
+            }
+        });
         invoker.invoke(exchange, params);
         verify(underlying).invoke(exchange, params);
     }


### PR DESCRIPTION
I found that the @UseAsyncMethod pattern for implementing non-blocking SOAP operations was broken, which seems to be due to the way these operations are dispatched conflicting with the parameter validation in dropwizard-jaxws.

I was able to get it working by skipping validation of parameters of type AsyncHandler, and I've also added an example of this pattern into the WsdlFirst service in the examples project.

It would be great if you can take this contribution, or use it to inspire your own implementation. Let me know if there's anything you would prefer to be done differently and I can update the pull request.