### PR TITLE
Support for publishedEndpointUrl.

### DIFF
--- a/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/JaxWsExampleApplication.java
+++ b/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/JaxWsExampleApplication.java
@@ -30,8 +30,8 @@ public class JaxWsExampleApplication extends Application<JaxWsExampleApplication
     };
 
     // JAX-WS Bundle
-    private JAXWSBundle jaxWsBundle = new JAXWSBundle();
-    private JAXWSBundle anotherJaxWsBundle = new JAXWSBundle("/api2");
+    private JAXWSBundle<Object> jaxWsBundle = new JAXWSBundle<>();
+    private JAXWSBundle<Object> anotherJaxWsBundle = new JAXWSBundle<>("/api2");
 
     public static void main(String[] args) throws Exception {
         new JaxWsExampleApplication().run(args);

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/EndpointBuilder.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/EndpointBuilder.java
@@ -13,6 +13,7 @@ public class EndpointBuilder extends AbstractBuilder {
 
     private String path;
     private Object service;
+    private String publishedEndpointUrl;
     SessionFactory sessionFactory;
     BasicAuthentication authentication;
 
@@ -22,6 +23,10 @@ public class EndpointBuilder extends AbstractBuilder {
 
     public Object getService() {
         return service;
+    }
+
+    public String publishedEndpointUrl() {
+        return publishedEndpointUrl;
     }
 
     public SessionFactory getSessionFactory() {
@@ -102,5 +107,10 @@ public class EndpointBuilder extends AbstractBuilder {
     @Override
     public EndpointBuilder enableMtom() {
         return (EndpointBuilder)super.enableMtom();
+    }
+
+    public EndpointBuilder publishedEndpointUrl(String publishedEndpointUrl) {
+        this.publishedEndpointUrl = publishedEndpointUrl;
+        return this;
     }
 }

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/JAXWSEnvironment.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/JAXWSEnvironment.java
@@ -45,10 +45,6 @@ public class JAXWSEnvironment {
     }
 
     public JAXWSEnvironment(String defaultPath) {
-        this(defaultPath, null);
-    }
-    public JAXWSEnvironment(String defaultPath, String publishedEndpointUrlPrefix) {
-        this.publishedEndpointUrlPrefix = publishedEndpointUrlPrefix;
 
         System.setProperty("org.apache.cxf.Logger", "org.apache.cxf.common.logging.Slf4jLogger");
         /*
@@ -66,6 +62,10 @@ public class JAXWSEnvironment {
         CXFNonSpringServlet cxf = new CXFNonSpringServlet();
         cxf.setBus(bus);
         return cxf;
+    }
+
+    public void setPublishedEndpointUrlPrefix(String publishedEndpointUrlPrefix) {
+        this.publishedEndpointUrlPrefix = publishedEndpointUrlPrefix;
     }
 
     public void setInstrumentedInvokerBuilder(InstrumentedInvokerFactory instrumentedInvokerBuilder) {

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/JAXWSEnvironment.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/JAXWSEnvironment.java
@@ -18,9 +18,12 @@ import javax.servlet.http.HttpServlet;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import javax.ws.rs.core.UriBuilder;
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.handler.Handler;
 import javax.xml.ws.soap.SOAPBinding;
+
+import java.net.URL;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -35,12 +38,17 @@ public class JAXWSEnvironment {
     protected final String defaultPath;
     private InstrumentedInvokerFactory instrumentedInvokerBuilder;
     private UnitOfWorkInvokerFactory unitOfWorkInvokerBuilder = new UnitOfWorkInvokerFactory();
+    private String publishedEndpointUrlPrefix;
 
     public String getDefaultPath() {
         return this.defaultPath;
     }
 
     public JAXWSEnvironment(String defaultPath) {
+        this(defaultPath, null);
+    }
+    public JAXWSEnvironment(String defaultPath, String publishedEndpointUrlPrefix) {
+        this.publishedEndpointUrlPrefix = publishedEndpointUrlPrefix;
 
         System.setProperty("org.apache.cxf.Logger", "org.apache.cxf.common.logging.Slf4jLogger");
         /*
@@ -98,6 +106,12 @@ public class JAXWSEnvironment {
         checkArgument(endpointBuilder != null, "EndpointBuilder is null");
 
         EndpointImpl cxfendpoint = new EndpointImpl(bus, endpointBuilder.getService());
+        if(endpointBuilder.publishedEndpointUrl() != null) {
+            cxfendpoint.setPublishedEndpointUrl(endpointBuilder.publishedEndpointUrl());
+        }
+        else if(publishedEndpointUrlPrefix != null) {
+            cxfendpoint.setPublishedEndpointUrl(publishedEndpointUrlPrefix + endpointBuilder.getPath());
+        }
         cxfendpoint.publish(endpointBuilder.getPath());
 
         // MTOM support

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/EndpointBuilderTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/EndpointBuilderTest.java
@@ -15,6 +15,7 @@ public class EndpointBuilderTest {
     public void buildEndpoint() {
         Object service = new Object();
         String path = "/foo";
+        String publishedUrl = "http://external/url";
         BasicAuthentication basicAuth = mock(BasicAuthentication.class);
         SessionFactory sessionFactory = mock(SessionFactory.class);
         Interceptor<? extends Message> inInterceptor = mock(Interceptor.class);
@@ -23,6 +24,7 @@ public class EndpointBuilderTest {
         Interceptor<? extends Message> outFaultInterceptor = mock(Interceptor.class);
 
         EndpointBuilder builder = new EndpointBuilder(path, service)
+                .publishedEndpointUrl(publishedUrl)
                 .authentication(basicAuth)
                 .sessionFactory(sessionFactory)
                 .cxfInInterceptors(inInterceptor, inInterceptor)
@@ -32,6 +34,7 @@ public class EndpointBuilderTest {
 
         assertThat(builder.getPath(), equalTo(path));
         assertThat(builder.getService(), equalTo(service));
+        assertThat(builder.publishedEndpointUrl(), equalTo(publishedUrl));
         assertThat(builder.getAuthentication(), equalTo(basicAuth));
         assertThat(builder.getSessionFactory(), equalTo(sessionFactory));
         assertThat(builder.getCxfInInterceptors(), contains(inInterceptor, inInterceptor));

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSBundleTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSBundleTest.java
@@ -61,7 +61,7 @@ public class JAXWSBundleTest {
         JAXWSBundle jaxwsBundle = new JAXWSBundle("/soap", jaxwsEnvironment);
 
         try {
-            jaxwsBundle.run(null);
+            jaxwsBundle.run(null, null);
         }
         catch (Exception e) {
             assertThat(e, is(instanceOf(IllegalArgumentException.class)));
@@ -70,10 +70,37 @@ public class JAXWSBundleTest {
         jaxwsBundle.initialize(bootstrap);
         verify(jaxwsEnvironment).setInstrumentedInvokerBuilder(any(InstrumentedInvokerFactory.class));
 
-        jaxwsBundle.run(environment);
+        jaxwsBundle.run(null, environment);
         verify(servletEnvironment).addServlet(startsWith("CXF Servlet"), any(Servlet.class));
         verify(lifecycleEnvironment).addServerLifecycleListener(any(ServerLifecycleListener.class));
         verify(servlet).addMapping("/soap/*");
+        verify(jaxwsEnvironment, never()).setPublishedEndpointUrlPrefix(anyString());
+    }
+
+    @Test
+    public void initializeAndRunWithPublishedEndpointUrlPrefix() {
+        JAXWSBundle jaxwsBundle = new JAXWSBundle("/soap", jaxwsEnvironment) {
+            @Override
+            protected String getPublishedEndpointUrlPrefix(Object configuration) {
+                return "http://some/prefix";
+            }
+        };
+
+        try {
+            jaxwsBundle.run(null, null);
+        }
+        catch (Exception e) {
+            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+        }
+
+        jaxwsBundle.initialize(bootstrap);
+        verify(jaxwsEnvironment).setInstrumentedInvokerBuilder(any(InstrumentedInvokerFactory.class));
+
+        jaxwsBundle.run(null, environment);
+        verify(servletEnvironment).addServlet(startsWith("CXF Servlet"), any(Servlet.class));
+        verify(lifecycleEnvironment).addServerLifecycleListener(any(ServerLifecycleListener.class));
+        verify(servlet).addMapping("/soap/*");
+        verify(jaxwsEnvironment).setPublishedEndpointUrlPrefix("http://some/prefix");
     }
 
     @Test

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSEnvironmentTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSEnvironmentTest.java
@@ -285,22 +285,8 @@ public class JAXWSEnvironmentTest {
 
     @Test
     public void publishEndpointWithPublishedUrlPrefix() throws WSDLException {
-        jaxwsEnvironment = new JAXWSEnvironment("soap", "http://external/prefix") {
-            @Override
-            protected BasicAuthenticationInterceptor createBasicAuthenticationInterceptor() {
-                return new BasicAuthenticationInterceptor() {
-                    @Override
-                    public void handleMessage(Message message) throws Fault {
-                        mockBasicAuthInterceptorInvoked++;
-                    }
-                };
-            }
-        };
 
-        testutils.setBus(jaxwsEnvironment.bus);
-        jaxwsEnvironment.setUnitOfWorkInvokerBuilder(mockUnitOfWorkInvokerBuilder);
-        jaxwsEnvironment.setInstrumentedInvokerBuilder(mockInvokerBuilder);
-
+        jaxwsEnvironment.setPublishedEndpointUrlPrefix("http://external/prefix");
 
         jaxwsEnvironment.publishEndpoint(
                 new EndpointBuilder("/path", service)

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSEnvironmentTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSEnvironmentTest.java
@@ -3,6 +3,8 @@ package com.roskart.dropwizard.jaxws;
 import ch.qos.logback.classic.Level;
 import org.apache.cxf.Bus;
 import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.frontend.WSDLGetUtils;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Exchange;
@@ -12,6 +14,7 @@ import org.apache.cxf.phase.Phase;
 import org.apache.cxf.service.invoker.Invoker;
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.test.TestUtilities;
+import org.apache.cxf.transport.AbstractDestination;
 import org.apache.cxf.transport.http.HTTPConduit;
 import org.apache.cxf.transport.local.LocalTransportFactory;
 import org.apache.cxf.transport.servlet.CXFNonSpringServlet;
@@ -27,6 +30,7 @@ import javax.jws.WebMethod;
 import javax.jws.WebService;
 import javax.mail.internet.MimeMultipart;
 import javax.mail.util.ByteArrayDataSource;
+import javax.wsdl.WSDLException;
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.handler.Handler;
 import javax.xml.ws.soap.SOAPBinding;
@@ -260,6 +264,56 @@ public class JAXWSEnvironmentTest {
         assertThat(mimeMultipart.getCount(), equalTo(1));
         testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse",
                 StaxUtils.read(mimeMultipart.getBodyPart(0).getInputStream()));
+    }
+
+    @Test
+    public void publishEndpointWithCustomPublishedUrl() throws Exception {
+        jaxwsEnvironment.publishEndpoint(
+                new EndpointBuilder("local://path", service)
+                        .publishedEndpointUrl("http://external.server/external/path")
+        );
+
+        verify(mockInvokerBuilder).create(any(), any(Invoker.class));
+        verifyZeroInteractions(mockUnitOfWorkInvokerBuilder);
+
+        Server server = testutils.getServerForAddress("local://path");
+        AbstractDestination destination = (AbstractDestination) server.getDestination();
+        String publishedEndpointUrl = destination.getEndpointInfo().getProperty(WSDLGetUtils.PUBLISHED_ENDPOINT_URL, String.class);
+
+        assertThat(publishedEndpointUrl, equalTo("http://external.server/external/path"));
+    }
+
+    @Test
+    public void publishEndpointWithPublishedUrlPrefix() throws WSDLException {
+        jaxwsEnvironment = new JAXWSEnvironment("soap", "http://external/prefix") {
+            @Override
+            protected BasicAuthenticationInterceptor createBasicAuthenticationInterceptor() {
+                return new BasicAuthenticationInterceptor() {
+                    @Override
+                    public void handleMessage(Message message) throws Fault {
+                        mockBasicAuthInterceptorInvoked++;
+                    }
+                };
+            }
+        };
+
+        testutils.setBus(jaxwsEnvironment.bus);
+        jaxwsEnvironment.setUnitOfWorkInvokerBuilder(mockUnitOfWorkInvokerBuilder);
+        jaxwsEnvironment.setInstrumentedInvokerBuilder(mockInvokerBuilder);
+
+
+        jaxwsEnvironment.publishEndpoint(
+                new EndpointBuilder("/path", service)
+        );
+
+        verify(mockInvokerBuilder).create(any(), any(Invoker.class));
+        verifyZeroInteractions(mockUnitOfWorkInvokerBuilder);
+
+        Server server = testutils.getServerForAddress("/path");
+        AbstractDestination destination = (AbstractDestination) server.getDestination();
+        String publishedEndpointUrl = destination.getEndpointInfo().getProperty(WSDLGetUtils.PUBLISHED_ENDPOINT_URL, String.class);
+
+        assertThat(publishedEndpointUrl, equalTo("http://external/prefix/path"));
     }
 
     @Test


### PR DESCRIPTION
Added support for customising the URLs advertised in WSDLs at runtime to match externally visible URLs. Visible in the location attribute of <soap:address>.

I hope you think this is a useful contribution - it's something I found I needed to do for an application I'm writing.