### PR TITLE
Null pointer on missing credentials

### DIFF
--- a/dropwizard-jaxws-example/pom.xml
+++ b/dropwizard-jaxws-example/pom.xml
@@ -57,6 +57,13 @@
             <artifactId>mail</artifactId>
             <version>1.4.4</version>
         </dependency>
+
+        <dependency>
+            <groupId>javax.jws</groupId>
+            <artifactId>javax.jws-api</artifactId>
+            <version>1.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/dropwizard-jaxws/pom.xml
+++ b/dropwizard-jaxws/pom.xml
@@ -76,6 +76,19 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>javax.jws</groupId>
+            <artifactId>javax.jws-api</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+            <version>2.1</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/dropwizard-jaxws/pom.xml
+++ b/dropwizard-jaxws/pom.xml
@@ -76,19 +76,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>javax.jws</groupId>
-            <artifactId>javax.jws-api</artifactId>
-            <version>1.1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
-            <version>2.1</version>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/BasicAuthenticationInterceptor.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/BasicAuthenticationInterceptor.java
@@ -50,7 +50,7 @@ public class BasicAuthenticationInterceptor extends AbstractPhaseInterceptor<Mes
 
         try {
             AuthorizationPolicy policy = message.get(AuthorizationPolicy.class);
-            if (policy != null) {
+            if (policy != null && policy.getUserName() != null && policy.getPassword() != null) {
                 credentials = new BasicCredentials(policy.getUserName(), policy.getPassword());
             } else {
                 // try the WS-Security UsernameToken

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/BasicAuthenticationInterceptorTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/BasicAuthenticationInterceptorTest.java
@@ -1,0 +1,109 @@
+package com.roskart.dropwizard.jaxws;
+
+import static com.roskart.dropwizard.jaxws.BasicAuthenticationInterceptor.PRINCIPAL_KEY;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.roskart.dropwizard.jaxws.auth.BasicAuthenticator;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.security.Principal;
+import org.apache.cxf.configuration.security.AuthorizationPolicy;
+import org.apache.cxf.interceptor.InterceptorChain;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.ExchangeImpl;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.transport.Conduit;
+import org.apache.cxf.transport.Destination;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class BasicAuthenticationInterceptorTest {
+
+    @Mock
+    private InterceptorChain interceptorChainMock;
+    @Mock
+    private Destination destinationMock;
+    @Mock
+    private Conduit conduitMock;
+    @Mock
+    private Message inMessageMock;
+    @Mock
+    private Message outMessageMock;
+    @Mock
+    private OutputStream outputStreamMock;
+
+    private BasicAuthentication basicAuthentication = new BasicAuthentication(new BasicAuthenticator(), "TOP_SECRET");
+    // Suppress warning about "hard-coded" password
+    @SuppressWarnings("squid:S2068")
+    private static final String CORRECT_PASSWORD = "secret";
+    private static final String USERNAME = "username";
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.initMocks(this);
+        when(destinationMock.getBackChannel(any())).thenReturn(conduitMock);
+        when(outMessageMock.getContent(OutputStream.class)).thenReturn(outputStreamMock);
+    }
+
+    @Test
+    public void shouldAuthenticateValidUser() {
+        BasicAuthenticationInterceptor target = new BasicAuthenticationInterceptor();
+        target.setAuthenticator(basicAuthentication);
+        Message message = createMessageWithUsernameAndPassword(USERNAME, CORRECT_PASSWORD);
+
+        target.handleMessage(message);
+
+        verify(inMessageMock).put(eq(PRINCIPAL_KEY), any(Principal.class));
+    }
+
+    @Test
+    public void shouldNotCrashOnNullPassword() {
+        BasicAuthenticationInterceptor target = new BasicAuthenticationInterceptor();
+        target.setAuthenticator(basicAuthentication);
+        Message message = createMessageWithUsernameAndPassword(USERNAME, null);
+
+        target.handleMessage(message);
+
+        verify(outMessageMock).put(Message.RESPONSE_CODE, HttpURLConnection.HTTP_UNAUTHORIZED);
+    }
+
+    @Test
+    public void shouldNotCrashOnNullUser() {
+        BasicAuthenticationInterceptor target = new BasicAuthenticationInterceptor();
+        target.setAuthenticator(basicAuthentication);
+        Message message = createMessageWithUsernameAndPassword(null, CORRECT_PASSWORD);
+
+        target.handleMessage(message);
+
+        verify(outMessageMock).put(Message.RESPONSE_CODE, HttpURLConnection.HTTP_UNAUTHORIZED);
+    }
+
+    private Message createMessageWithUsernameAndPassword(String username, String password) {
+        Message message = createEmptyMessage();
+
+        AuthorizationPolicy policy = new AuthorizationPolicy();
+        policy.setUserName(username);
+        policy.setPassword(password);
+        message.put(AuthorizationPolicy.class, policy);
+        return message;
+    }
+
+    private Message createEmptyMessage() {
+        Exchange exchange = new ExchangeImpl();
+        exchange.setInMessage(inMessageMock);
+        exchange.setOutMessage(outMessageMock);
+        exchange.setDestination(destinationMock);
+
+        Message message = new MessageImpl();
+        message.setExchange(exchange);
+        message.setInterceptorChain(interceptorChainMock);
+        return message;
+    }
+}

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/auth/BasicAuthenticator.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/auth/BasicAuthenticator.java
@@ -1,0 +1,19 @@
+package com.roskart.dropwizard.jaxws.auth;
+
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.basic.BasicCredentials;
+import java.util.Optional;
+
+/**
+ * BasicAuthenticator is copied from dropwizard-example.
+ */
+public class BasicAuthenticator implements Authenticator<BasicCredentials, User> {
+    @Override
+    public Optional<User> authenticate(BasicCredentials credentials) throws AuthenticationException {
+        if ("secret".equals(credentials.getPassword())) {
+            return Optional.of(new User(credentials.getUsername()));
+        }
+        throw new AuthenticationException("Invalid credentials");
+    }
+}

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/auth/User.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/auth/User.java
@@ -1,0 +1,19 @@
+package com.roskart.dropwizard.jaxws.auth;
+
+import java.security.Principal;
+
+/**
+ * See dropwizard-example: com.example.helloworld.core.User
+ */
+public class User implements Principal {
+    private final String userName;
+
+    public User(String userName) {
+        this.userName = userName;
+    }
+
+    @Override
+    public String getName() {
+        return this.userName;
+    }
+}


### PR DESCRIPTION
If the supplied username or password in a request are null there is a nasty NullPointerException in the logs and the caller service receives an "Internal server error" message.
Add a null check for username and password, if either is null the authorization process should check the security token instead.