### PR TITLE
Update to Dropwizard 2.0.0

### DIFF
--- a/dropwizard-jaxws-example/pom.xml
+++ b/dropwizard-jaxws-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dropwizard-jaxws-parent</artifactId>
         <groupId>com.github.roskart.dropwizard-jaxws</groupId>
-        <version>1.1.0</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/db/PersonDAO.java
+++ b/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/db/PersonDAO.java
@@ -5,6 +5,7 @@ import com.roskart.dropwizard.jaxws.example.core.Person;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
 
 import java.util.List;
 
@@ -40,6 +41,9 @@ public class PersonDAO extends AbstractDAO<Person> {
     }
 
     public List<Person> findAll() {
-        return list(namedQuery("com.roskart.dropwizard.jaxws.example.core.Person.findAll"));
+        @SuppressWarnings("unchecked")
+        Query<Person> query =
+                (Query<Person>) namedQuery("com.roskart.dropwizard.jaxws.example.core.Person.findAll");
+        return list(query);
     }
 }

--- a/dropwizard-jaxws/pom.xml
+++ b/dropwizard-jaxws/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dropwizard-jaxws-parent</artifactId>
         <groupId>com.github.roskart.dropwizard-jaxws</groupId>
-        <version>1.1.0</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/ValidatingInvoker.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/ValidatingInvoker.java
@@ -1,6 +1,5 @@
 package com.roskart.dropwizard.jaxws;
 
-import com.google.common.collect.ImmutableList;
 import io.dropwizard.validation.Validated;
 import io.dropwizard.validation.ConstraintViolations;
 import org.apache.cxf.helpers.CastUtils;
@@ -15,6 +14,7 @@ import javax.validation.ValidationException;
 import javax.validation.groups.Default;
 import javax.xml.ws.AsyncHandler;
 import java.lang.annotation.Annotation;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -80,7 +80,7 @@ public class ValidatingInvoker extends AbstractInvoker {
         final Class<?>[] classes = findValidationGroups(annotations);
 
         if (classes != null) {
-            final ImmutableList<String> errors = ConstraintViolations.format(
+            final Collection<String> errors = ConstraintViolations.format(
                     validator.validate(value, classes));
 
             if (!errors.isEmpty()) {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.roskart.dropwizard-jaxws</groupId>
     <artifactId>dropwizard-jaxws-parent</artifactId>
-    <version>1.1.0</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
     <name>Dropwizard JAX-WS</name>
     <description>
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <dropwizard.version>1.3.13</dropwizard.version>
+        <dropwizard.version>2.0.0</dropwizard.version>
         <cxf.version>3.2.9</cxf.version>
 
     </properties>


### PR DESCRIPTION
* Update project version to 2.0.0 in all POMs
* Update dropwizard.version property in parent POM to 2.0.0
* Fix compilation error in ValidatingInvoker due to Dropwizard 2
  changing return type in ConstraintViolations.format from
  ImmutableList<String> to Collection<String>
* Fix compilation error in PersonDAO.findAll due to Dropwizard 2
  changing return type in AbstractDAO.namedQuery from
  Query to Query<?>, which unfortunately requires a cast (and
  suppressed the unchecked cast warning as well)