### PR TITLE
Updated maven usage in README with version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use dropwizard-jaxws in your project, add the following dependency to your `p
         <dependency>
             <groupId>com.github.roskart.dropwizard-jaxws</groupId>
             <artifactId>dropwizard-jaxws</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
 
 Hello World


### PR DESCRIPTION
Changed the usage in the README so that the Maven Usage section has the new version (1.2.0)