### PR TITLE
Resolve #33: Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <dropwizard.version>2.0.24</dropwizard.version>
-        <cxf.version>3.4.4</cxf.version>
+        <dropwizard.version>2.0.29</dropwizard.version>
+        <cxf.version>3.5.2</cxf.version>
 
     </properties>
 
@@ -147,14 +147,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
- Upgraded to CXF 3.5.2 (see Issue #33).
- Upgraded to Dropwizard 2.0.29 (see Issue #33).
- Bump junit from 4.13.1 to 4.13.2 (see Issue #33).
- Bump mockito from 1.9.5 to 1.10.19 (see Issue #33).